### PR TITLE
Fix error with parsing order completed and paid date from timestamp

### DIFF
--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -145,7 +145,23 @@ class Order extends Post
     {
         $value = $this->getMeta('_date_completed');
 
-        return $value ? Carbon::parse($value) : null;
+        if ($value !== null) {
+            return Carbon::createFromTimestamp($value);
+        }
+
+        /**
+         * WooCommerce in version 2.6.x has stored completed date in
+         * "_completed_date" meta field in MySQL datetime format.
+         */
+        $value = $this->getMeta('_completed_date');
+
+        if ($value !== null) {
+            $datetime = Carbon::createFromFormat('Y-m-d H:i:s', $value);
+
+            return $datetime !== false ? $datetime : null;
+        }
+
+        return null;
     }
 
     /**
@@ -157,7 +173,23 @@ class Order extends Post
     {
         $value = $this->getMeta('_date_paid');
 
-        return $value ? Carbon::parse($value) : null;
+        if ($value !== null) {
+            return Carbon::createFromTimestamp($value);
+        }
+
+        /**
+         * WooCommerce in version 2.6.x has stored paid date in "_paid_date"
+         * meta field in MySQL datetime format.
+         */
+        $value = $this->getMeta('_paid_date');
+
+        if ($value !== null) {
+            $datetime = Carbon::createFromFormat('Y-m-d H:i:s', $value);
+
+            return $datetime !== false ? $datetime : null;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Unit/Model/OrderTest.php
+++ b/tests/Unit/Model/OrderTest.php
@@ -66,7 +66,7 @@ class OrderTest extends TestCase
     public function testDateCompletedProperty(): void
     {
         $order = $this->createOrder();
-        $order->createMeta('_date_completed', '2020-01-01 00:00:00');
+        $order->createMeta('_date_completed', 1577836800); // '2020-01-01 00:00:00'
 
         $this->assertInstanceOf(Carbon::class, $order->date_completed);
         $this->assertSame('2020-01-01 00:00:00', $order->date_completed->format('Y-m-d H:i:s')); // @phpstan-ignore-line
@@ -75,7 +75,20 @@ class OrderTest extends TestCase
     public function testDatePaidProperty(): void
     {
         $order = $this->createOrder();
-        $order->createMeta('_date_paid', '2020-01-01 01:00:00');
+        $order->createMeta('_date_paid', 1577840400); // '2020-01-01 01:00:00'
+
+        $this->assertInstanceOf(Carbon::class, $order->date_paid);
+        $this->assertSame('2020-01-01 01:00:00', $order->date_paid->format('Y-m-d H:i:s')); // @phpstan-ignore-line
+    }
+
+    public function testDeprecatedDateFormats(): void
+    {
+        $order = $this->createOrder();
+        $order->createMeta('_completed_date', '2020-01-01 00:00:00');
+        $order->createMeta('_paid_date', '2020-01-01 01:00:00');
+
+        $this->assertInstanceOf(Carbon::class, $order->date_completed);
+        $this->assertSame('2020-01-01 00:00:00', $order->date_completed->format('Y-m-d H:i:s')); // @phpstan-ignore-line
 
         $this->assertInstanceOf(Carbon::class, $order->date_paid);
         $this->assertSame('2020-01-01 01:00:00', $order->date_paid->format('Y-m-d H:i:s')); // @phpstan-ignore-line


### PR DESCRIPTION
Fixes #18 

For backward compatibility, WooCommerce stores completed and paid date in two formats - MySQL datetime and timestamp. We should use timestamps, because MySQL datetime format was used in 2.6.x version of Woo and will be dropped in 4.0 version.