### PR TITLE
Update WooCommerce.php

### DIFF
--- a/src/WooCommerce.php
+++ b/src/WooCommerce.php
@@ -17,9 +17,9 @@ class WooCommerce
     /**
      * Get the shop currency.
      *
-     * @return  string
+     * @return  string|null
      */
-    public static function currency(): string
+    public static function currency(): ?string
     {
         if (self::$currency === null) {
             self::$currency = Option::get('woocommerce_currency');


### PR DESCRIPTION
Small fix for the type, but this can easily break your app if not fixed. (It broke mine)
It can happen rather easily for instance when woocommerce is not installed, this will return null and therefore an exception will be thrown.

Types can become dangerous (Not the ones in comments of course).