### PR TITLE
Support Corcel v8 for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^8.2",
         "illuminate/database": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
-        "jgrossi/corcel": "^7.0",
+        "jgrossi/corcel": "^7.0|^8.0",
         "nesbot/carbon": "^2.66|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds support for Corcel ^8.0 as it is required to upgrade to Laravel 11.

Laravel Shift was able to detect this when authoring PR #35 but did not when authoring PR #37.